### PR TITLE
remove trailing whitespace ('\n') from base64

### DIFF
--- a/monitoring/alerting/README.md
+++ b/monitoring/alerting/README.md
@@ -4,7 +4,7 @@ Alerting is part of cluster monitoring, where alert notifications are sent to th
 
 ## Prerequisite
 
-Prometheus, Grafana, and alert manager tools are needed to set up alert notifications. [Install monitoring](../monitoring/README.md).
+Prometheus, Grafana, and alert manager tools are needed to set up alert notifications. [Install monitoring](../README.md).
 
 
 ## Slack alerts notification

--- a/monitoring/alerting/install.sh
+++ b/monitoring/alerting/install.sh
@@ -2,7 +2,7 @@
 # Patch notification alerts 
 
 echo Patching alert manager secrets 
-kubectl patch secret alertmanager-rancher-monitoring-alertmanager -n cattle-monitoring-system  --patch="{\"data\": { \"alertmanager.yaml\": \"$(cat ./alertmanager.yaml |base64)\" }}"
+kubectl patch secret alertmanager-rancher-monitoring-alertmanager -n cattle-monitoring-system  --patch="{\"data\": { \"alertmanager.yaml\": \"$(cat ./alertmanager.yaml |base64 |tr -d '\n' )\" }}"
 echo Regenerating secrets
 kubectl delete secret alertmanager-rancher-monitoring-alertmanager-generated -n cattle-monitoring-system
 echo Adding cluster name


### PR DESCRIPTION
- fix broken link from documentation 
- fix `Error from server (BadRequest): invalid character '\n' in string literal` where encoding base64 leaves a new line at the end