### PR TITLE
[MOSIP-43540] added required TLS version and cipher configurations

### DIFF
--- a/nginx/esignet/nginx.conf.sample
+++ b/nginx/esignet/nginx.conf.sample
@@ -39,6 +39,15 @@ http {
     #ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
     #ssl_prefer_server_ciphers on;
 
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    ssl_ciphers 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:!ECDSA:!SHA1:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!RC4';
+
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+    ssl_session_tickets off;
+
     ##
     # Logging Settings
     ##

--- a/nginx/mosip/nginx.conf.sample
+++ b/nginx/mosip/nginx.conf.sample
@@ -39,6 +39,18 @@ http {
     #ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
     #ssl_prefer_server_ciphers on;
 
+    #ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+    #ssl_prefer_server_ciphers on;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    ssl_ciphers 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:!ECDSA:!SHA1:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!RC4';
+
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+    ssl_session_tickets off;
+
     ##
     # Logging Settings
     ##


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated nginx configuration templates with modern SSL/TLS protocol versions (TLSv1.2 and TLSv1.3) and explicit cipher suite specifications
* Implemented SSL session caching with configurable timeout settings and disabled session ticket-based sessions for improved session management across deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->