### PR TITLE
[MOSIP-44531]  Fix script name in cron job setup

### DIFF
--- a/utils/ssl_renewel_util/certs_renew_cron.sh
+++ b/utils/ssl_renewel_util/certs_renew_cron.sh
@@ -19,6 +19,6 @@ cron_time="0 0 $adjusted_date *"
 echo "Cron time: $cron_time"
 
 # Create a cron job to exicute the renew_certificates.sh script on the expiry date without manual intervention
-echo "$cron_time ./renew_certificates" | crontab -
+echo "$cron_time ./renew_ssl_certs.sh" | crontab -
 
 echo "Scheduled job for $cron_time to run at 12am."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSL certificate renewal scheduled task to execute the correct renewal script, ensuring certificates renew as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->