### PR TITLE
Closes #197 Typo in subsequent control plane node names in hosts.ini.sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
       * [RKE2](./k8-cluster/on-prem/rke2/README.md) based k8 cluster creation steps.
   * Cloud service providers:
     * [AWS](./k8-cluster/csp/aws/README.md) : based k8 cluster creation steps.
+* [monitoring](./monitoring/README.md)
 * [Ingress](./ingress/README.md) : Setup steps for ingress in k8 cluster to espose services.
 * [Storage class](./storage-class) : Steps to setup and configure multiple types of storage classes for k8 cluster.
   * [nfs](./storage-class/nfs/README.md).
@@ -22,7 +23,6 @@
 * [Nginx](./nginx/) Webserver deployment steps. Used for exposing services to external world along with ingress in on-prem mode k8s clusters.
 * [Alerting](./alerting/README.md)
 * [logging](./logging/README.md)
-* [monitoring](./monitoring/README.md)
 * [Observation stack](observtaion/README.md) setup.
   * Contains below mentions apps for Observation stack.
     * [Rancher UI](apps/rancher-ui/README.md) Rancher UI installation.

--- a/k8-cluster/on-prem/rke2/README.md
+++ b/k8-cluster/on-prem/rke2/README.md
@@ -8,59 +8,69 @@ The following guide uses [RKE2](https://docs.rke2.io/) to set up the Kubernetes 
 * The following tools are installed on all the VM's/machines and the client machine.
   ```ufw , wget , curl , kubectl , istioctl , helm , jq```
 ## Firewall Setup
-Set up firewall rules on each of the VM's/machines. The following uses ufw to setup firewall.
-* `ufw` commands to be executed on each of the VM's/machines:
-  * SSH into each node VM/machine super user or change to superuser.
-  * Run the following command for each rule in the following table
-    ```
-    ufw allow from <from-ip-range-allowed> to any port <port/range> proto <tcp/udp>
-    ```
-  * Example
-    ```
-    ufw allow from any to any port 22 proto tcp
-    ufw allow from 10.3.4.0/24 to any port 9345 proto tcp
-    ```
-  * Enable ufw.
-    ```
-    ufw enable
-    ufw default deny incoming
-    ```
+You can set up firewall rules on each of the VM's/machines either automatically using Ansible (recommended) or manually. The following uses `ufw` to setup the firewall.
+
+### Automated Setup via Ansible (Recommended)
+You can use the provided Ansible scripts to automatically open the required ports and disable swap across all nodes.
+* Configure `Wireguard conf` and establish wireguard tunnel with Wireguard Bastion server.
+* Install [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) on your personal computer or machine used to perform deployment.
+* Navigate to the `ansible` directory and prepare the inventory:
+  ```
+  cd ansible
+  cp hosts.ini.sample hosts.ini
+  ```
+* Update `hosts.ini` with proper details of all the VM's/machines.
+* Execute Ansible command to open port on each node:
+  ```
+  ansible-playbook -i hosts.ini ports.yaml
+  ```
+* Disable swap (perhaps not needed as swap is already disabled).
+  ```
+  ansible-playbook -i hosts.ini swap.yaml
+  ```
+
+### Manual Setup
+If you prefer not to use Ansible, you must manually run `ufw` commands on each of the VM's/machines.
+* SSH into each node VM/machine super user or change to superuser.
+* Run the following command for each rule in the following table
+  ```
+  ufw allow from <from-ip-range-allowed> to any port <port/range> proto <tcp/udp>
+  ```
+* Example
+  ```
+  ufw allow from any to any port 22 proto tcp
+  ufw allow from 10.3.4.0/24 to any port 9345 proto tcp
+  ```
+* Enable ufw.
+  ```
+  ufw enable
+  ufw default deny incoming
+  ```
 * Additional reference : [ RKE2 Networking Requirements](https://docs.rke2.io/install/requirements#networking).
-* Ports to be opened in server nodes:
-  |Protocal|Port|Accesibility|Description|
-  |---|---|---|---|
-  |TCP|22|RKE2 server and agent nodes over wireguard|SSH|
-  |TCP|80|RKE2 server and agent nodes|Internal traffic|
-  |TCP|443|RKE2 server and agent nodes|External traffic (if any apart fron nginx/loadbalancer)|
-  |TCP|2381|RKE2 server and agent nodes|etcd metrics port|
-  |TCP|2379|RKE2 server and agent nodes|etcd client port|
-  |TCP|2380|RKE2 server and agent nodes|etcd peer port|
-  |TCP|10250|RKE2 server and agent nodes|kubelet metrics|
-  |TCP|9345|RKE2 server and agent nodes|RKE2 supervisor API|
-  |TCP|6443|RKE2 server and agent nodes|Kubernetes API|
-  |UDP|8472|RKE2 server and agent nodes|Canal CNI with VXLAN|
-  |TCP|9099|RKE2 server and agent nodes|Canal CNI health checks|    
-  |TCP|30000-32767|RKE2 server and agent nodes|NodePort port range|
-* Ports to be opened in agent nodes
-  |Protocal|Port|Accesibility|Description|
-  |---|---|---|---|
-  |TCP|22|RKE2 server and agent nodes over wireguard|SSH|
-  |TCP|80|RKE2 server and agent nodes|Internal traffic|
-  |TCP|443|RKE2 server and agent nodes|External traffic (if any apart fron nginx/loadbalancer)|
-  |TCP|10250|RKE2 server and agent nodes|kubelet metrics|
-* Ansible script to be used for opening ports via `ufw` on all VM's/machines.
-  * Configure `Wireguard conf` and establish wireguard tunnel with Wireguard Bastion server.
-  * Install [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) on your personel computer or machine used to perform deployment.
-  * Create a copy of `hosts.ini.sample` as `hosts.ini`.
-  * Update `hosts.ini` with proper details of all the VM's/machines.
-  * Execute Ansible command to open port on each nodes:
-    ```
-    ansible-playbook -i hosts.ini ports.yaml
-    ```
-  * Disable swap (perhaps not needed as swap is already disabled).
-    ```
-    ansible-playbook -i hosts.ini swap.yaml
-    ```
+
+#### Ports to be opened in server nodes:
+|Protocal|Port|Accesibility|Description|
+|---|---|---|---|
+|TCP|22|RKE2 server and agent nodes over wireguard|SSH|
+|TCP|80|RKE2 server and agent nodes|Internal traffic|
+|TCP|443|RKE2 server and agent nodes|External traffic (if any apart fron nginx/loadbalancer)|
+|TCP|2381|RKE2 server and agent nodes|etcd metrics port|
+|TCP|2379|RKE2 server and agent nodes|etcd client port|
+|TCP|2380|RKE2 server and agent nodes|etcd peer port|
+|TCP|10250|RKE2 server and agent nodes|kubelet metrics|
+|TCP|9345|RKE2 server and agent nodes|RKE2 supervisor API|
+|TCP|6443|RKE2 server and agent nodes|Kubernetes API|
+|UDP|8472|RKE2 server and agent nodes|Canal CNI with VXLAN|
+|TCP|9099|RKE2 server and agent nodes|Canal CNI health checks|    
+|TCP|30000-32767|RKE2 server and agent nodes|NodePort port range|
+
+#### Ports to be opened in agent nodes
+|Protocal|Port|Accesibility|Description|
+|---|---|---|---|
+|TCP|22|RKE2 server and agent nodes over wireguard|SSH|
+|TCP|80|RKE2 server and agent nodes|Internal traffic|
+|TCP|443|RKE2 server and agent nodes|External traffic (if any apart fron nginx/loadbalancer)|
+|TCP|10250|RKE2 server and agent nodes|kubelet metrics|
 ## K8s setup
 You can set up the RKE2 cluster either automatically using Ansible (recommended) or manually.
 

--- a/k8-cluster/on-prem/rke2/README.md
+++ b/k8-cluster/on-prem/rke2/README.md
@@ -62,6 +62,20 @@ Set up firewall rules on each of the VM's/machines. The following uses ufw to se
     ansible-playbook -i hosts.ini swap.yaml
     ```
 ## K8s setup
+You can set up the RKE2 cluster either automatically using Ansible (recommended) or manually.
+
+### Automated Setup via Ansible (Recommended)
+The automated deployment uses the provided Ansible playbooks to install and configure the RKE2 cluster across all nodes. This is the preferred and less error-prone way to deploy the cluster.
+
+* Ensure you have updated `hosts.ini` with all your node details and disabled swap using `swap.yaml`.
+* Execute the main Ansible playbook to provision the RKE2 Cluster:
+  ```
+  cd ansible
+  ansible-playbook -i hosts.ini main.yaml
+  ```
+* For detailed instructions, refer to the [Ansible Setup README](./ansible/README.md).
+
+### Manual Setup
 * Different types of nodes to be referenced moving ahead.
   * **Primary server node** : 
     * First node used for creating RKE2 k8 cluster is called primary server node.

--- a/k8-cluster/on-prem/rke2/ansible/hosts.ini.sample
+++ b/k8-cluster/on-prem/rke2/ansible/hosts.ini.sample
@@ -4,7 +4,7 @@ control-plane-1 ansible_host=<internal ip> ansible_user=root ansible_ssh_private
 
 # Subsequent control plane nodes. These are additional control plane nodes that will be added to the cluster after the Primary control plane node and it has also all the roles (control-plane, etcd, master, agent). Number of nodes to be added is based upon your requirement of HA.
 [control_plane_subsequent]
-control-subsequent_plane-1 ansible_host=<internal ip> ansible_user=root ansible_ssh_private_key_file=<pvt .pem file>
+control-subsequent-plane-1 ansible_host=<internal ip> ansible_user=root ansible_ssh_private_key_file=<pvt .pem file>
 
 # agent nodes. These nodes will run application workloads and number of nodes to be defined depends upon the required no of worker considering in sandbox the load is getting shared with primary and secondary server node.
 [agents]

--- a/nginx/mosip/hosts.ini.sample
+++ b/nginx/mosip/hosts.ini.sample
@@ -1,3 +1,3 @@
-[cluster]
+[nginx]
 node1 ansible_host=<internal ip> ansible_user=root ansible_ssh_private_key_file=<pvt .pem file>
 node2 ansible_host=<internal ip> ansible_user=root ansible_ssh_private_key_file=<pvt .pem file>

--- a/storage-class/nfs/hosts.ini.sample
+++ b/storage-class/nfs/hosts.ini.sample
@@ -1,2 +1,2 @@
 [nfs]
-node-nfs  ansible_host=<internal ip> ansible_user=root ansible_ssh_private_key_file=<pvt .pem file>
+node-nfs ansible_host=<internal ip> ansible_user=root ansible_ssh_private_key_file=<pvt .pem file>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated host entry naming convention in the RKE2 cluster configuration sample for consistency with standard naming practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/k8s-infra/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->