### PR TITLE
Closes #197 Typo in subsequent control plane node names in hosts.ini.…

### DIFF
--- a/k8-cluster/on-prem/rke2/ansible/hosts.ini.sample
+++ b/k8-cluster/on-prem/rke2/ansible/hosts.ini.sample
@@ -4,7 +4,7 @@ control-plane-1 ansible_host=<internal ip> ansible_user=root ansible_ssh_private
 
 # Subsequent control plane nodes. These are additional control plane nodes that will be added to the cluster after the Primary control plane node and it has also all the roles (control-plane, etcd, master, agent). Number of nodes to be added is based upon your requirement of HA.
 [control_plane_subsequent]
-control-subsequent_plane-1 ansible_host=<internal ip> ansible_user=root ansible_ssh_private_key_file=<pvt .pem file>
+control-subsequent-plane-1 ansible_host=<internal ip> ansible_user=root ansible_ssh_private_key_file=<pvt .pem file>
 
 # agent nodes. These nodes will run application workloads and number of nodes to be defined depends upon the required no of worker considering in sandbox the load is getting shared with primary and secondary server node.
 [agents]


### PR DESCRIPTION
…sample

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated host naming convention in cluster configuration for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/k8s-infra/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->