### PR TITLE
Closes #211 NFS Server & Client Setup – Mismatch Between Documentation and Script

### DIFF
--- a/storage-class/nfs/README.md
+++ b/storage-class/nfs/README.md
@@ -17,29 +17,33 @@
   ```
   ansible-playbook -i ./hosts.ini nfs-ports.yaml
   ```
-* Login to the NFS node and execute `./install-nfs-server.sh` to deploy the NFS server for a specific environment.
-* While deploying the NFS server, you have to pass the environment Name.
-* Location in NFS server nodes for that specific environment will be `/srv/nfs/mosip/<envName>`.
-  ```
+* Login to the NFS node to deploy the NFS server.
+* The script uses environment variables to set the configuration:
+  * `NFS_SERVER_LOCATION`: The directory path for the NFS storage (default: `/srv/nfs`)
+  * `NFS_USER`: The user created for NFS operations (default: `nfsnobody`)
+* To use the defaults, simply run:
+  ```bash
   sudo ./install-nfs-server.sh
-  .....
-  Please Enter Environment Name: <envName>
-  .....
-  .....
-  .....
-  [ Export the NFS Share Directory ] 
-  exporting *:/srv/nfs/mosip/<envName>
-  
-  NFS Server Path: /srv/nfs/mosip/<envName>
+  ```
+* To configure custom paths or a specific environment, pass the variables:
+  ```bash
+  sudo NFS_SERVER_LOCATION=/correct/path NFS_USER=nfsnobody ./install-nfs-server.sh
   ```
 ## NFS Client Provisioner Installation
 * Run `./install-nfs-csi.sh` to deploy NFS client provisioner.
-  ```
+* The script supports interactive prompts, but you can also provide environment variables for a non-interactive installation:
+  * `NFS_SERVER`: The IP or hostname of the NFS server
+  * `NFS_SERVER_LOCATION`: The NFS path on the server
+* To install interactively:
+  ```bash
   ./install-nfs-csi.sh
-    .....
-    .....
-    Please provide NFS SERVER: <NFS-SERVER>
-    Please provide NFS Path: <NFS-SERVER-PATH>
+  .....
+  Please provide NFS SERVER: <NFS-SERVER>
+  Please provide NFS Path: <NFS-SERVER-PATH>
+  ```
+* To install non-interactively using variables:
+  ```bash
+  NFS_SERVER=<NFS-SERVER> NFS_SERVER_LOCATION=<NFS-SERVER-PATH> ./install-nfs-csi.sh
   ```
 ## Post installation steps
 * Check status of NFS Client Provisioner.
@@ -86,9 +90,8 @@
   <name>  Bound    pvc-36d6e3ce-59bb-4f96-aea2-07c673356fac   5Gi        RWX            nfs-csi     60s
   ```
 
-
 ## Uninstall NFS Client Provisioner
-* Run `./delete-nfs-csi.sh` to uninstall `nfs-csi ` helm/chart.
-  ```
-  ./delete-nfs-csi.sh
+* Run `./delete-nfs-cient-csi.sh` to uninstall `nfs-csi` helm/chart.
+  ```bash
+  ./delete-nfs-cient-csi.sh
   ```

--- a/storage-class/nfs/README.md
+++ b/storage-class/nfs/README.md
@@ -30,31 +30,25 @@
   sudo NFS_SERVER_LOCATION=/correct/path NFS_USER=nfsnobody ./install-nfs-server.sh
   ```
 ## NFS Client Provisioner Installation
-* Run `./install-nfs-csi.sh` to deploy NFS client provisioner.
-* The script supports interactive prompts, but you can also provide environment variables for a non-interactive installation:
+* The script uses environment variables for installation:
   * `NFS_SERVER`: The IP or hostname of the NFS server
   * `NFS_SERVER_LOCATION`: The NFS path on the server
-* To install interactively:
-  ```bash
-  ./install-nfs-csi.sh
-  .....
-  Please provide NFS SERVER: <NFS-SERVER>
-  Please provide NFS Path: <NFS-SERVER-PATH>
-  ```
-* To install non-interactively using variables:
+* Install the provisioner by running the script with the required variables. Replace the `<NFS-SERVER>` and `<NFS-SERVER-PATH>` placeholders with your actual server IP and path:
   ```bash
   NFS_SERVER=<NFS-SERVER> NFS_SERVER_LOCATION=<NFS-SERVER-PATH> ./install-nfs-csi.sh
   ```
 ## Post installation steps
 * Check status of NFS Client Provisioner.
   ```
-  kubectl -n nfs get deployment.apps/csi-driver-nfs
+  kubectl get deploy -n nfs
+  NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
+  csi-nfs-controller   1/1     1            1           40s
   ```
 * check status of `nfs-csi` storage class.
   ```
    kubectl get storageclass
-   NAME                 PROVISIONER                            RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
-   nfs-csi           cluster.local/nfs-csi                     Retain          Immediate           true                   40s
+   NAME                 PROVISIONER                     RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
+   nfs-csi(default)     nfs.csi.k8s.io                  Delete          Immediate           false                  40s
   ```
 
 * Login to the NFS node and check NFS server status:


### PR DESCRIPTION
…setup scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated NFS server setup instructions to use environment variables (`NFS_SERVER_LOCATION`, `NFS_USER`) with clear default and custom command examples.
  * Refreshed NFS client provisioner installation guidance using `NFS_SERVER` and `NFS_SERVER_LOCATION`, including non-interactive examples.
  * Adjusted verification and output snippets for controller deployment and the `nfs-csi` storage class.
  * Corrected uninstall script reference to `./delete-nfs-cient-csi.sh`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->